### PR TITLE
Added more assertions for pointer capture events

### DIFF
--- a/pointer-prefix.js
+++ b/pointer-prefix.js
@@ -24,7 +24,7 @@ pointerPrefix = (function() {
 			lostpointercapture: "lostpointercapture",
 			maxTouchPoints: "maxTouchPoints",
 			pointerType: { "mouse": "mouse", "touch": "touch", "stylus": "stylus" },
-			touchAction: "touch-action",
+			touchAction: "touchAction",
 			PointerEvent: PointerEvent,
 			setPointerCapture: "setPointerCapture",
 			releasePointerCapture: "releasePointerCapture"
@@ -45,7 +45,7 @@ pointerPrefix = (function() {
 			lostpointercapture: "MSLostPointerCapture",
 			maxTouchPoints: "msMaxTouchPoints",
 			pointerType: { "mouse": 4, "touch": 2, "stylus": 99 },
-			touchAction: "-ms-touch-action",
+			touchAction: "msTouchAction",
 			PointerEvent: MSPointerEvent,
 			setPointerCapture: "msSetPointerCapture",
 			releasePointerCapture: "msReleasePointerCapture"

--- a/pointer-prefix.js
+++ b/pointer-prefix.js
@@ -5,7 +5,7 @@
  * properties. To simplify development of the W3C tests,
  * this file abstracts names of the events and properties.
  */
- pointerPrefix = (function() {
+pointerPrefix = (function() {
 
 	// Use maxTouchPoints as our feature detect; this will
 	// probably need tweaking with new implementations.
@@ -25,8 +25,10 @@
 			maxTouchPoints: "maxTouchPoints",
 			pointerType: { "mouse": "mouse", "touch": "touch", "stylus": "stylus" },
 			touchAction: "touch-action",
-			PointerEvent: PointerEvent
-		};		
+			PointerEvent: PointerEvent,
+			setPointerCapture: "setPointerCapture",
+			releasePointerCapture: "releasePointerCapture"
+		};
 	}
 	else if ( "msMaxTouchPoints" in window.navigator ) {
 		return {
@@ -39,16 +41,17 @@
 			pointerout: "MSPointerOut",
 			pointerenter: "MSPointerEnter",
 			pointerleave: "MSPointerLeave",
-			gotpointercapture: "gotpointercapture",
-			lostpointercapture: "lostpointercapture",
+			gotpointercapture: "MSGotPointerCapture",
+			lostpointercapture: "MSLostPointerCapture",
 			maxTouchPoints: "msMaxTouchPoints",
 			pointerType: { "mouse": 4, "touch": 2, "stylus": 99 },
 			touchAction: "-ms-touch-action",
-			PointerEvent: MSPointerEvent
+			PointerEvent: MSPointerEvent,
+			setPointerCapture: "msSetPointerCapture",
+			releasePointerCapture: "msReleasePointerCapture"
 		};
 	}
 	else {
 		//TODO: Assert no pointer events?
 	}
- }());
- 
+}());

--- a/pointercaptureevents.html
+++ b/pointercaptureevents.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<!--
+	Test cases for Pointer Events v1 spec
+-->
+<head>
+	<title>Pointer Events Capture Events Tests</title>
+	<meta name="viewport" content="width=device-width">
+	<link rel="author" href="mailto:rodrigos@outlook.com">
+	<link rel="help" href="http://www.w3.org/wiki/PointerEvents/TestAssertions">
+	<link rel="stylesheet" href="testharness.css"/>
+	<!-- http://w3c-test.org/resources/testharness.js -->
+	<script src="testharness.js"></script>
+	<script src="pointer-prefix.js"></script>
+	<script>
+		var test_capture = async_test("Capture events");
+
+		function run() {
+			var target = document.getElementById("target");
+			var capturedId = -1;
+			var syncTestFlag;
+			var pointerCaptured = false;
+			var pointerReleased = false;
+
+			function onPointerEvent(event) {
+				if (pointerCaptured) {
+					test(function() {
+						assert_true(event.type === pointerPrefix["gotpointercapture"],
+							"First event to fire after setPointerCapture was " + pointerPrefix["gotpointercapture"])
+					}, "First event to fire after setPointerCapture was " + pointerPrefix["gotpointercapture"]);
+					pointerCaptured = false;
+				}
+
+				if (pointerReleased) {
+					test(function() {
+						assert_true(event.type === pointerPrefix["lostpointercapture"],
+								"First event to fire after releasePointerCapture was " + pointerPrefix["lostpointercapture"])
+					}, "First event to fire after releasePointerCapture was " + pointerPrefix["lostpointercapture"]);
+					pointerReleased = false;
+				}
+			}
+
+			[
+				"pointerdown",
+				"pointerup",
+				"pointercancel",
+				"pointermove",
+				"pointerover",
+				"pointerout",
+				"pointerenter",
+				"gotpointercapture",
+				"lostpointercapture"
+			].forEach(function(eventName){
+				on_event(target, pointerPrefix[eventName], onPointerEvent)
+			});
+
+			on_event(target, pointerPrefix["pointerdown"], function(event) {
+				capturedId = event.pointerId;
+				syncTestFlag = false;
+				target[pointerPrefix["setPointerCapture"]](capturedId);
+				pointerCaptured = true;
+				syncTestFlag = true;
+			});
+
+			on_event(target, pointerPrefix["gotpointercapture"], function(event) {
+				test(function(){
+					assert_true(syncTestFlag, "gotpointercapture fired asynchronously");
+				}, "gotpointercapture fired asynchronously");
+				test(function() {
+					assert_true(event.pointerId === capturedId,
+						"gotpointercapture event received for pointerId " + capturedId);
+				}, "gotpointercapture event received for pointerId " + capturedId);
+			});
+
+			on_event(target, pointerPrefix["pointerup"], function(event) {
+				test(function() {
+					assert_true(event.pointerId === capturedId,
+						"pointerup event received for same id as pointer up " + capturedId);
+				}, "pointerup event received for same id as pointer up " + capturedId);
+
+				syncTestFlag = false;
+				target[pointerPrefix["releasePointerCapture"]](capturedId);
+				pointerReleased = true;
+				syncTestFlag = true;
+			});
+
+			on_event(target, pointerPrefix["lostpointercapture"], function(event) {
+				test(function(){
+					assert_true(syncTestFlag, "lostpointercapture fired asynchronously");
+				}, "lostpointercapture fired asynchronously");
+				test(function() {
+					assert_true(event.pointerId === capturedId,
+						"lostpointercapture event received for pointerId " + capturedId);
+				}, "lostpointercapture event received for pointerId " + capturedId);
+
+				test_capture.done();
+			});
+		}
+
+	</script>
+	<style>
+		#target {
+			padding: 2em;
+			background: yellow;
+			border: 2px solid green;
+			text-align: center;
+			color: blue;
+		}
+	</style>
+</head>
+<body onload="run()">
+	<h1>Pointer Events Capture Events Tests</h1>
+	<div id="target">
+		Click here
+	</div>
+	<div id="log"></div>
+</body>
+</html>

--- a/pointercaptureevents.html
+++ b/pointercaptureevents.html
@@ -112,7 +112,7 @@
 	<h1>Pointer Events Capture Events Tests</h1>
 	<div id="target">
 		Click or tap here
-l	</div>
+	</div>
 	<div id="log"></div>
 </body>
 </html>

--- a/pointercaptureevents.html
+++ b/pointercaptureevents.html
@@ -14,29 +14,65 @@
 	<script src="pointer-prefix.js"></script>
 	<script>
 		var test_capture = async_test("Capture events");
+		var test_related_target = async_test("Check target and relatedTarget");
 
 		function run() {
 			var target = document.getElementById("target");
 			var capturedId = -1;
 			var syncTestFlag;
 			var pointerCaptured = false;
-			var pointerReleased = false;
+			var seenPointerCaptured = false;
+			var seenPointerReleased = false;
+			target.style[pointerPrefix["touchAction"]] = "none";
+
+			// NOTE: Not using assert_throws because it doesn't support InvalidPointerId
+			test(function() {
+				try {
+					target[pointerPrefix["setPointerCapture"]](-1);
+					assert_true(false, "Calling releasePointerCapture with invalid id didn't throw.");
+				} catch (ex) {
+					assert_equals(ex.name, "InvalidPointerId");
+				}
+			}, "Calling setPointerCapture with invalid id should throw InvalidPointerId DOMException");
+
+			test(function() {
+				try {
+					target[pointerPrefix["releasePointerCapture"]](-1);
+					assert_true(false, "Calling releasePointerCapture with invalid id didn't throw.");
+				} catch (ex) {
+					assert_equals(ex.name, "InvalidPointerId");
+				}
+			}, "Calling releasePointerCapture with invalid id should throw InvalidPointerId DOMException");
 
 			function onPointerEvent(event) {
-				if (pointerCaptured) {
+				if (event.pointerId !== capturedId)
+					return;
+
+				if (seenPointerCaptured) {
 					test(function() {
 						assert_equals(event.type, pointerPrefix["gotpointercapture"],
 							"First event to fire after setPointerCapture was " + pointerPrefix["gotpointercapture"])
 					}, "First event to fire after setPointerCapture was " + pointerPrefix["gotpointercapture"]);
-					pointerCaptured = false;
+					seenPointerCaptured = false;
+					return;
 				}
 
-				if (pointerReleased) {
+				if (seenPointerReleased) {
 					test(function() {
 						assert_equals(event.type, pointerPrefix["lostpointercapture"],
 								"First event to fire after releasePointerCapture was " + pointerPrefix["lostpointercapture"])
 					}, "First event to fire after releasePointerCapture was " + pointerPrefix["lostpointercapture"]);
-					pointerReleased = false;
+					seenPointerReleased = false;
+					return;
+				}
+
+				if (pointerCaptured) {
+					test_related_target.step(function() {
+						assert_equals(event.target, target,
+							"target of all pointer events should be the captuting element.");
+						assert_equals(event.relatedTarget, null,
+							"relatedTarget for all pointer events should be null while captuging.");
+					});
 				}
 			}
 
@@ -49,16 +85,21 @@
 				"pointerout",
 				"pointerenter",
 				"gotpointercapture",
-				"lostpointercapture"
+				"lostpointercapture",
+				"mousedown",
+				"mouseup",
+				"mousemove",
+				"mouseover",
+				"mouseout"
 			].forEach(function(eventName){
-				on_event(target, pointerPrefix[eventName], onPointerEvent)
+				on_event(target, pointerPrefix[eventName], onPointerEvent);
 			});
 
 			on_event(target, pointerPrefix["pointerdown"], function(event) {
 				capturedId = event.pointerId;
 				syncTestFlag = false;
 				target[pointerPrefix["setPointerCapture"]](capturedId);
-				pointerCaptured = true;
+				seenPointerCaptured = true;
 				syncTestFlag = true;
 			});
 
@@ -67,20 +108,21 @@
 					assert_true(syncTestFlag, "gotpointercapture fired asynchronously");
 				}, "gotpointercapture fired asynchronously");
 				test(function() {
-					assert_true(event.pointerId === capturedId,
+					assert_equals(event.pointerId, capturedId,
 						"gotpointercapture event received for pointerId " + capturedId);
 				}, "gotpointercapture event received for pointerId " + capturedId);
+				pointerCaptured = true;
 			});
 
 			on_event(target, pointerPrefix["pointerup"], function(event) {
 				test(function() {
-					assert_true(event.pointerId === capturedId,
+					assert_equals(event.pointerId, capturedId,
 						"pointerup event received for same id as pointer up " + capturedId);
 				}, "pointerup event received for same id as pointer up " + capturedId);
 
 				syncTestFlag = false;
 				target[pointerPrefix["releasePointerCapture"]](capturedId);
-				pointerReleased = true;
+				seenPointerReleased = true;
 				syncTestFlag = true;
 			});
 
@@ -89,10 +131,12 @@
 					assert_true(syncTestFlag, "lostpointercapture fired asynchronously");
 				}, "lostpointercapture fired asynchronously");
 				test(function() {
-					assert_true(event.pointerId === capturedId,
+					assert_equals(event.pointerId, capturedId,
 						"lostpointercapture event received for pointerId " + capturedId);
 				}, "lostpointercapture event received for pointerId " + capturedId);
 
+				pointerCaptured = false;
+				test_related_target.done();
 				test_capture.done();
 			});
 		}


### PR DESCRIPTION
Added assert for invalid pointerId when calling set/releasePointerCapture method.
Test for target and release target while capturing.
